### PR TITLE
Prepare repo for Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+backend/venv/
+
+# Node artifacts
+frontend/node_modules/
+frontend/build/
+
+# Environment files
+.env
+*.env
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# ClearTrack
+
+This project contains a FastAPI backend and a React frontend.
+
+## Development
+
+Run the backend with:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+Run the frontend with:
+
+```bash
+cd frontend
+npm start
+```
+
+## Deployment
+
+[Vercel](https://vercel.com/) is used for deployment. The configuration in
+`vercel.json` builds the frontend from the `frontend/` directory and exposes the
+FastAPI app as a serverless function under `/api`.
+
+Install the Vercel CLI and run `vercel` from the project root to deploy.
+Environment variables for the backend can be configured in the Vercel dashboard.

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,3 @@
+from backend.main import app
+
+# Vercel detects the `app` variable as the ASGI application

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,8 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 import { TrendingUp, TrendingDown, Plus, X, Loader } from 'lucide-react';
 
 // API Service
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+// On Vercel the API is served from the same domain so the default is empty
+const API_URL = process.env.REACT_APP_API_URL || '';
 
 const api = {
   async getHoldings() {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.py", "use": "@vercel/python" },
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "frontend/build" } }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "api/index.py" },
+    { "src": "/(.*)", "dest": "frontend/build/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- update API URL handling in React app for same-domain API
- configure Vercel with a Python function and static build
- expose FastAPI app through `api/index.py`
- add gitignore and usage instructions

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685700f3590c8330b312addb6221c3c2